### PR TITLE
add variable into the main.tf file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,4 +2,6 @@ module "logging" {
 
 source = "./modules/logging"
     environment          = var.environment
+    s3_bucket_name       = var.s3_bucket_name
+    s3_source_arn_event_notification = var.s3_source_arn_event_notification
 }

--- a/modules/logging/iam-role.tf
+++ b/modules/logging/iam-role.tf
@@ -20,7 +20,7 @@ resource "aws_iam_role" "lambda_forward_logs_s3_cloudwatch_role" {
 EOF
   tags = merge({
     Name = "${var.environment}-iam-role"
-  }, var.tags
+  }
   )
 }
 

--- a/modules/logging/lambda.tf
+++ b/modules/logging/lambda.tf
@@ -42,7 +42,7 @@ resource "aws_lambda_permission" "allow_bucket_forward_logs" {
     function_name = aws_lambda_function.forward_logs_s3_cloudwatch.arn
     principal     = "s3.amazonaws.com"
     source_arn    = var.s3_source_arn_event_notification
-    source_account = var.account_id
+#    source_account = var.account_id
 }
 
 // To manually configure in the console

--- a/provider.tf
+++ b/provider.tf
@@ -9,7 +9,7 @@ terraform {
 
 # define AWS as provider
 provider "aws" {
-    region = "ap-southeast-1"
+    region = var.region
 }
 
 // If you want to store your terraform state in S3

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,10 @@ variable "environment" {
   description = "Code Environment"
 }
 
+variable "region" {
+  description = "Resource deployment region"
+}
+
 variable "s3_source_arn_event_notification" {
   description = "The S3 ARN that will trigger the lambda through even notification"
 }


### PR DESCRIPTION
- As I checked need to add variable of s3 bucket name & ARN into main file.
- For single account maybe not need to add AWS account number. So, we can pass that parameter as a optional.
- Also, we can remove below things from iam-role.tf file.
<img width="364" alt="Screenshot 2023-05-21 at 9 29 36 PM" src="https://github.com/xinweiiiii/AWS-logs-forwarding-s3-to-cloudwatch/assets/63643548/0a5dfba5-92ea-4cb8-810c-d0f0a95408cd">
